### PR TITLE
Add test dependencies flag to go get

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -31,7 +31,7 @@ phases:
       - cd "/go/src/${PACKAGE}"
 
       # Fetch all dependencies
-      - go get ./...
+      - go get -t ./...
 
       # Ensure code passes all lint tests
       - golint -set_exit_status


### PR DESCRIPTION
When running this build on CodeBuild, test dependencies were not fetched, which led to PRE_BUILD errors as follows:

```
main_test.go:9:2: cannot find package "github.com/stretchr/testify/assert" in any of: /usr/local/go/src/github.com/stretchr/testify/assert (from $GOROOT) /go/src/github.com/stretchr/testify/assert (from $GOPATH) /codebuild/output/src283397697/src/github.com/stretchr/testify/assert
```

By adding the `-t` flag, dependencies for tests are also fetched. More information on flags available for `go get` are available in the [documentation for the get package](https://golang.org/pkg/cmd/go/internal/get/#pkg-variables)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.