### PR TITLE
add main name to import function

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -3,7 +3,7 @@ package main_test
 import (
 	"testing"
 
-	"github.com/aws-samples/lambda-go-samples"
+	main "github.com/aws-samples/lambda-go-samples"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
*Description of changes:*
I just made the changes to `main_test.go` which follow the [docs](https://aws.amazon.com/blogs/compute/announcing-go-support-for-aws-lambda/). without the rename of `main` for the "package" `github.com/aws-samples/lambda-go-samples` , `main_test.go` will not be able to find the package namespace `main`. 

However, this still does not fix the problem that since `main.go` is not actually a package (it is a program driver). I am not entirely sure how to test a main program in this way in idiomatic go, but I hope this gets a little closer to the fix.

The exact message in my code is:
```
main_test.go|6 col 2 error| import "github.com/aws-samples/lambda-go-samples" is a program, not an importable package
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
